### PR TITLE
fix: t is not defined

### DIFF
--- a/pages/projekte/_id.vue
+++ b/pages/projekte/_id.vue
@@ -74,7 +74,7 @@ export default {
     },
     proceeding_and_rank () {
       return [this.verfahren, this.preis]
-        .map(t => t.trim())
+        .map(t => t?.trim())
         .filter(t => t)
         .join(', ')
     }


### PR DESCRIPTION
When proceeding and prize are blank trimming wont work because `t` is nil. This fixes makes the call to `trim` safe and fixes the bug.
